### PR TITLE
Fix PvxRate specials not loading

### DIFF
--- a/src/RatingListRenderer.php
+++ b/src/RatingListRenderer.php
@@ -76,21 +76,21 @@ class RatingListRenderer {
 
 				$total = $rating['rating'][0] * .8 + $rating['rating'][1] * .2 + $rating['rating'][2] * .0;
 				if ( $total < 3.75 ) {
-					$rating = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'trash\'\')';
+					$rating['text'] = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'trash\'\')';
 				} elseif ( $total < 4.75 ) {
-					$rating = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'good\'\')';
+					$rating['text']  = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'good\'\')';
 				} elseif ( $total >= 4.75 ) {
-					$rating = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'great\'\')';
+					$rating['text']  = 'Rating: \'\'\'' . $total . '\'\'\' (\'\'great\'\')';
 				}
 
 				if ( $rating['rollback'] ) {
-					$out .= '\'\'\'' . $admin_link . '\'\'\'' . ' removed ' . strtolower( $rating ) . ' posted by: ' .
+					$out .= '\'\'\'' . $admin_link . '\'\'\'' . ' removed ' . strtolower( $rating['text'] ) . ' posted by: ' .
 							$user_link;
 				} elseif ( !$rating['rollback'] && $rating['reason'] ) {
-					$out .= '\'\'\'' . $admin_link . '\'\'\'' . ' restored ' . strtolower( $rating ) . ' posted by: ' .
+					$out .= '\'\'\'' . $admin_link . '\'\'\'' . ' restored ' . strtolower( $rating['text'] ) . ' posted by: ' .
 							$user_link;
 				} else {
-					$out .= $rating;
+					$out .= $rating['text'] ;
 					$out .= ' . . ';
 					$out .= ' E:' . $rating['rating'][0];
 					$out .= ' U:' . $rating['rating'][1];


### PR DESCRIPTION
Fixes:
```
TypeError from line 86 of /extensions/PvXRate/src/RatingListRenderer.php: Cannot access offset of type string on string
	#0 /extensions/PvXRate/src/SpecialUserRatings.php(52): Fandom\PvXRate\RatingListRenderer->render(array, OutputPage, User, LanguageEn)
	#1 /includes/specialpage/SpecialPage.php(647): Fandom\PvXRate\SpecialUserRatings->execute(NULL)
	#2 /includes/specialpage/SpecialPageFactory.php(1366): SpecialPage->run(NULL)
	#3 /includes/MediaWiki.php(314): MediaWiki\SpecialPage\SpecialPageFactory->executePath(string, RequestContext)
	#4 /includes/MediaWiki.php(931): MediaWiki->performRequest()
	#5 /includes/MediaWiki.php(562): MediaWiki->main()
	#6 /index.php(53): MediaWiki->run()
	#7 /index.php(46): wfIndexMain()
	#8 {main}
```