### PR TITLE
Extract schema updates hook to its own handler

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -82,10 +82,13 @@
 		"main": {
 			"class": "Fandom\\PvXRate\\PvXRateHooks",
 			"services": ["NamespaceInfo"]
+		},
+		"db": {
+			"class": "Fandom\\PvXRate\\SchemaHooks"
 		}
 	},
 	"Hooks": {
-		"LoadExtensionSchemaUpdates": "main",
+		"LoadExtensionSchemaUpdates": "db",
 		"SkinTemplateNavigation::Universal": "main"
 	},
 	"callback": "Fandom\\PvXRate\\PvXRateHooks::onRegistration",

--- a/src/PvXRateHooks.php
+++ b/src/PvXRateHooks.php
@@ -5,7 +5,6 @@ declare( strict_types=1 );
 namespace Fandom\PvXRate;
 
 use MediaWiki\Hook\SkinTemplateNavigation__UniversalHook;
-use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use MWException;
 use NamespaceInfo;
 use SkinTemplate;
@@ -25,25 +24,13 @@ use User;
  * @link		https://gitlab.com/hydrawiki
  *
  */
-class PvXRateHooks implements
-	LoadExtensionSchemaUpdatesHook,
-	SkinTemplateNavigation__UniversalHook
-{
+class PvXRateHooks implements SkinTemplateNavigation__UniversalHook {
 
 	public function __construct( private NamespaceInfo $namespaceInfo ) {
 	}
 
 	public static function onRegistration(): void {
 		require_once __DIR__ . '/defines.php';
-	}
-
-	public function onLoadExtensionSchemaUpdates( $updater ) {
-		$updater->addExtensionUpdate( [
-			'addTable',
-			'rating',
-			__DIR__ . '/install/sql/table_rating.sql',
-			true,
-		] );
 	}
 
 	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {

--- a/src/SchemaHooks.php
+++ b/src/SchemaHooks.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Fandom\PvXRate;
+
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
+
+class SchemaHooks implements LoadExtensionSchemaUpdatesHook {
+	public function onLoadExtensionSchemaUpdates( $updater ) {
+		$updater->addExtensionUpdate( [
+			'addTable',
+			'rating',
+			__DIR__ . '/install/sql/table_rating.sql',
+			true,
+		] );
+	}
+}


### PR DESCRIPTION
In https://github.com/Wikia/pvxrate/pull/4 a hook interface was introduced to rewrite hooks from static members, but `onLoadExtensionSchemaUpdates` requires no service dependencies, as they might not be instantiated at that point. 
Use a separate handler for this case instead.